### PR TITLE
Fix: JSONDecodeError for status code 429.

### DIFF
--- a/datadis/__init__.py
+++ b/datadis/__init__.py
@@ -181,4 +181,8 @@ async def _request(
                 result.append(dict_to_typed(contract, output_type))
             return result
         else:
-            raise ConnectionError(f'Error: {r.json()["message"]}')
+            try:
+                message = r.json()["message"]
+            except Exception as e:
+                raise ConnectionError(f'Unknown error', dict(status_code=r.status_code, content=r.text, headers=r.headers)) from e
+            raise ConnectionError(f'Error: {message}')


### PR DESCRIPTION
This PR improves error handling in the _request function by addressing cases where the response is not valid JSON, such as when a status code of 429 (Too Many Requests) is returned.